### PR TITLE
Fix region selector integration in form demo

### DIFF
--- a/src/app/pages/form-demo/form-demo.ts
+++ b/src/app/pages/form-demo/form-demo.ts
@@ -44,7 +44,7 @@ import { MatCardModule }      from '@angular/material/card';
 import{ Country, Ethnic} from'../../shared/models/dict.model';
 import{DictService} from'../../shared/services/dict.service';
 import { MatSelect } from '@angular/material/select';
-import { RegionValue } from '../../shared/region-selector/region-selector';
+import { RegionValue, RegionSelectorComponent } from '../../shared/region-selector/region-selector';
 @Component({
   selector: 'app-form-demo',
   standalone: true,
@@ -53,7 +53,8 @@ import { RegionValue } from '../../shared/region-selector/region-selector';
     MatFormFieldModule, MatInputModule, MatSelectModule,
     MatRadioModule, MatCheckboxModule, MatDatepickerModule, MatNativeDateModule,
     MatSlideToggleModule, MatSliderModule, MatAutocompleteModule,
-    MatButtonModule, MatIconModule, MatCardModule,MatSelect
+    MatButtonModule, MatIconModule, MatCardModule, MatSelect,
+    RegionSelectorComponent
   ],
   templateUrl: './form-demo.html',
   styleUrls: ['./form-demo.scss']


### PR DESCRIPTION
## Summary
- import the shared RegionSelectorComponent into the form demo standalone component
- allow the region selector form control to register its ControlValueAccessor when using formControlName

## Testing
- ng build *(fails: bundle initial exceeded maximum budget constraint)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ac021df48331bd951245972a07e9