### PR TITLE
Fix keyword normalization in selector components

### DIFF
--- a/src/app/shared/ethnic-selector/ethnic-selector.ts
+++ b/src/app/shared/ethnic-selector/ethnic-selector.ts
@@ -104,7 +104,7 @@ export class EthnicSelectorComponent implements ControlValueAccessor, Validator 
     this.inputCtrl.valueChanges.pipe(startWith(''))
   ]).pipe(
     map(([list, keyword]) => {
-      const kw = keyword.trim().toLowerCase();
+      const kw = this.normalizeKeyword(keyword);
       if (!kw) {
         return list;
       }
@@ -146,7 +146,7 @@ export class EthnicSelectorComponent implements ControlValueAccessor, Validator 
   handleBlur() {
     this.touched.set(true);
     this.onTouched();
-    const txt = this.inputCtrl.value.trim();
+    const txt = this.normalizeKeyword(this.inputCtrl.value, false);
     if (!txt) {
       if (this.required) {
         this.value = null;
@@ -231,6 +231,17 @@ export class EthnicSelectorComponent implements ControlValueAccessor, Validator 
       const first = item.name_py_first?.trim().toLowerCase() ?? '';
       return kw === name || kw === full || kw === first;
     });
+  }
+
+  private normalizeKeyword(value: unknown, shouldLowercase = true): string {
+    const raw =
+      typeof value === 'string'
+        ? value
+        : value && typeof value === 'object'
+          ? this.displayEthnic(value as Ethnic)
+          : '';
+    const trimmed = raw.trim();
+    return shouldLowercase ? trimmed.toLowerCase() : trimmed;
   }
 
   private notifyChange() {

--- a/src/app/shared/nationality-selector/nationality-selector.ts
+++ b/src/app/shared/nationality-selector/nationality-selector.ts
@@ -104,7 +104,7 @@ export class NationalitySelectorComponent implements ControlValueAccessor, Valid
     this.inputCtrl.valueChanges.pipe(startWith(''))
   ]).pipe(
     map(([list, keyword]) => {
-      const kw = keyword.trim().toLowerCase();
+      const kw = this.normalizeKeyword(keyword);
       if (!kw) {
         return list;
       }
@@ -152,7 +152,7 @@ export class NationalitySelectorComponent implements ControlValueAccessor, Valid
   handleBlur() {
     this.touched.set(true);
     this.onTouched();
-    const txt = this.inputCtrl.value.trim();
+    const txt = this.normalizeKeyword(this.inputCtrl.value, false);
     if (!txt) {
       if (this.required) {
         this.value = null;
@@ -238,6 +238,17 @@ export class NationalitySelectorComponent implements ControlValueAccessor, Valid
       const py = country.name_py_first?.trim().toLowerCase() ?? '';
       return kw === nameCn || kw === nameEn || kw === code || kw === py;
     });
+  }
+
+  private normalizeKeyword(value: unknown, shouldLowercase = true): string {
+    const raw =
+      typeof value === 'string'
+        ? value
+        : value && typeof value === 'object'
+          ? this.displayCountry(value as Country)
+          : '';
+    const trimmed = raw.trim();
+    return shouldLowercase ? trimmed.toLowerCase() : trimmed;
   }
 
   private notifyChange() {


### PR DESCRIPTION
## Summary
- normalize autocomplete keywords in ethnic and nationality selectors to handle object values safely
- reuse display helpers to convert selected options when deriving search keywords

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4e7b273b483318be7a3a5c9a9320b