### PR TITLE
feat: add patient list and consultation workflows

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,12 @@
 import { Routes } from '@angular/router';
 import { FormDemoComponent } from './pages/form-demo/form-demo';
+import { PatientListComponent } from './pages/patient-list/patient-list';
+import { ConsultationComponent } from './pages/consultation/consultation';
 
 export const routes: Routes = [
-  { path: '', component: FormDemoComponent }
+  { path: '', redirectTo: 'patients', pathMatch: 'full' },
+  { path: 'patients', component: PatientListComponent },
+  { path: 'registration', component: FormDemoComponent },
+  { path: 'consultation/:id', component: ConsultationComponent },
+  { path: '**', redirectTo: 'patients' }
 ];

--- a/src/app/pages/consultation/consultation.html
+++ b/src/app/pages/consultation/consultation.html
@@ -1,0 +1,179 @@
+<section class="consultation-page" *ngIf="patient as current">
+  <header class="page-header">
+    <button mat-stroked-button class="back-button" (click)="goBack()">
+      <mat-icon>arrow_back</mat-icon>
+      返回患者列表
+    </button>
+    <div class="header-info">
+      <h1>{{ current.name }}的看诊工作台</h1>
+      <p class="subtitle">请在左侧选择功能，右侧查看或录入详细信息</p>
+    </div>
+  </header>
+
+  <section class="workspace">
+    <aside class="left-panel">
+      <mat-card class="patient-card">
+        <div class="card-header">
+          <div class="avatar">
+            <span>{{ current.name[0] }}</span>
+          </div>
+          <div class="identity">
+            <h2>{{ current.name }}</h2>
+            <p class="meta">{{ current.gender }} · {{ current.age }}岁</p>
+            <p class="id">卡号：{{ current.id }}</p>
+          </div>
+        </div>
+
+        <mat-divider></mat-divider>
+
+        <dl class="card-info">
+          <div>
+            <dt>就诊科室</dt>
+            <dd>{{ current.dept }}</dd>
+          </div>
+          <div>
+            <dt>主诊医生</dt>
+            <dd>{{ current.doctor }}</dd>
+          </div>
+          <div>
+            <dt>到诊时间</dt>
+            <dd>{{ current.visitTime }}</dd>
+          </div>
+          <div>
+            <dt>当前状态</dt>
+            <dd><span class="status">{{ current.status }}</span></dd>
+          </div>
+          <div>
+            <dt>过敏史</dt>
+            <dd>{{ current.allergies }}</dd>
+          </div>
+        </dl>
+
+        <mat-divider></mat-divider>
+
+        <div class="tag-container">
+          <span class="tag" *ngFor="let tag of current.tags">{{ tag }}</span>
+        </div>
+
+        <div class="notes">
+          <h3>就诊提示</h3>
+          <p>{{ current.notes }}</p>
+        </div>
+      </mat-card>
+
+      <nav class="feature-nav">
+        <h3>功能导航</h3>
+        <mat-nav-list>
+          <a
+            mat-list-item
+            *ngFor="let feature of features"
+            (click)="openFeature(feature)"
+            [class.active]="isFeatureActive(feature)"
+          >
+            <mat-icon matListIcon>{{ feature.icon }}</mat-icon>
+            <div matLine>{{ feature.title }}</div>
+            <p matLine class="description">{{ feature.description }}</p>
+            <mat-icon class="chevron">chevron_right</mat-icon>
+          </a>
+        </mat-nav-list>
+      </nav>
+    </aside>
+
+    <section class="right-panel">
+      <mat-card class="tab-shell">
+        <mat-tab-group
+          [selectedIndex]="activeTabIndex"
+          (selectedIndexChange)="activeTabIndex = $event"
+          animationDuration="250ms"
+        >
+          <mat-tab *ngFor="let tab of openTabs; let index = index">
+            <ng-template mat-tab-label>
+              <mat-icon>{{ tab.icon }}</mat-icon>
+              <span>{{ tab.title }}</span>
+              <button
+                mat-icon-button
+                type="button"
+                class="close"
+                (click)="closeTab(index, $event)"
+                [disabled]="openTabs.length === 1"
+                matTooltip="关闭"
+              >
+                <mat-icon>close</mat-icon>
+              </button>
+            </ng-template>
+
+            <div class="tab-content" [ngSwitch]="tab.id">
+              <div *ngSwitchCase="'diagnosis'" class="diagnosis">
+                <h3>初步诊断记录</h3>
+                <div class="grid">
+                  <div class="field">
+                    <label>主诉</label>
+                    <textarea rows="3" placeholder="请输入患者主诉信息"></textarea>
+                  </div>
+                  <div class="field">
+                    <label>既往史</label>
+                    <textarea rows="3" placeholder="填写既往病史、手术史"></textarea>
+                  </div>
+                  <div class="field full">
+                    <label>诊断结论</label>
+                    <textarea rows="4" placeholder="诊断评估与处理计划"></textarea>
+                  </div>
+                </div>
+                <div class="action-bar">
+                  <button mat-stroked-button color="primary">保存诊断</button>
+                  <button mat-flat-button color="primary">提交并同步</button>
+                </div>
+              </div>
+
+              <div *ngSwitchCase="'orders'" class="orders">
+                <h3>医嘱与处方</h3>
+                <div class="placeholder">
+                  <mat-icon>medication</mat-icon>
+                  <p>添加药品或检查项目，系统将自动校验冲突并生成医嘱清单。</p>
+                  <button mat-raised-button color="primary">新增处方</button>
+                </div>
+              </div>
+
+              <div *ngSwitchCase="'records'" class="records">
+                <h3>电子病历</h3>
+                <ul>
+                  <li>
+                    <span class="label">体格检查</span>
+                    <p>生命体征稳定，建议持续监测血压与血糖。</p>
+                  </li>
+                  <li>
+                    <span class="label">辅助检查</span>
+                    <p>建议安排心电图与血常规，排查心肌缺血风险。</p>
+                  </li>
+                </ul>
+              </div>
+
+              <div *ngSwitchCase="'certificate'" class="certificate">
+                <h3>疾病证明</h3>
+                <div class="placeholder">
+                  <mat-icon>verified</mat-icon>
+                  <p>根据诊断信息生成疾病证明或休假建议。</p>
+                  <button mat-raised-button color="primary">生成证明</button>
+                </div>
+              </div>
+
+              <div *ngSwitchCase="'consent'" class="consent">
+                <h3>知情同意书</h3>
+                <div class="placeholder">
+                  <mat-icon>assignment_turned_in</mat-icon>
+                  <p>向患者解释诊疗风险与注意事项，签署知情同意书。</p>
+                  <button mat-raised-button color="primary">发起签署</button>
+                </div>
+              </div>
+
+              <div *ngSwitchDefault class="empty">
+                <mat-icon>info</mat-icon>
+                <p>{{ getTabDescription(tab.id) }}</p>
+              </div>
+            </div>
+          </mat-tab>
+        </mat-tab-group>
+      </mat-card>
+    </section>
+  </section>
+</section>

--- a/src/app/pages/consultation/consultation.scss
+++ b/src/app/pages/consultation/consultation.scss
@@ -1,0 +1,436 @@
+$primary-color: #1976d2;
+$secondary-color: #12426f;
+$surface-color: #f5f8ff;
+$text-muted: #5c6b7c;
+
+.consultation-page {
+  min-height: 100vh;
+  padding: 32px 48px 48px;
+  background: linear-gradient(135deg, rgba(19, 71, 129, 0.08), rgba(25, 118, 210, 0.15));
+  box-sizing: border-box;
+  color: #1c2b3a;
+
+  .page-header {
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    margin-bottom: 24px;
+
+    .back-button {
+      border-radius: 999px;
+      padding: 0 18px;
+      height: 42px;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-color: rgba(25, 118, 210, 0.3);
+      color: $secondary-color;
+
+      mat-icon {
+        font-size: 20px;
+      }
+    }
+
+    .header-info {
+      h1 {
+        margin: 0;
+        font-size: 28px;
+        font-weight: 600;
+        color: $secondary-color;
+      }
+
+      .subtitle {
+        margin: 6px 0 0;
+        color: $text-muted;
+        font-size: 15px;
+      }
+    }
+  }
+
+  .workspace {
+    display: grid;
+    grid-template-columns: 340px 1fr;
+    gap: 24px;
+  }
+
+  .left-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+
+    .patient-card {
+      border-radius: 22px;
+      background: rgba(255, 255, 255, 0.95);
+      box-shadow: 0 18px 40px rgba(17, 71, 128, 0.16);
+      border: 1px solid rgba(25, 118, 210, 0.12);
+      padding: 24px;
+
+      .card-header {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        margin-bottom: 16px;
+
+        .avatar {
+          width: 56px;
+          height: 56px;
+          border-radius: 18px;
+          background: linear-gradient(135deg, #1f6fbb, #37a8ff);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          color: #fff;
+          font-size: 24px;
+          font-weight: 600;
+        }
+
+        .identity {
+          h2 {
+            margin: 0;
+            font-size: 22px;
+          }
+
+          .meta {
+            margin: 4px 0;
+            color: $text-muted;
+            font-size: 14px;
+          }
+
+          .id {
+            font-size: 13px;
+            color: rgba(18, 66, 111, 0.6);
+            letter-spacing: 0.4px;
+          }
+        }
+      }
+
+      mat-divider {
+        margin: 16px 0;
+      }
+
+      .card-info {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px 16px;
+
+        dt {
+          font-size: 12px;
+          text-transform: uppercase;
+          letter-spacing: 0.6px;
+          color: rgba(18, 66, 111, 0.55);
+          margin-bottom: 4px;
+        }
+
+        dd {
+          margin: 0;
+          font-size: 14px;
+          color: #1d364d;
+        }
+
+        .status {
+          display: inline-flex;
+          align-items: center;
+          padding: 4px 12px;
+          border-radius: 999px;
+          background: rgba(25, 118, 210, 0.12);
+          color: $primary-color;
+          font-size: 12px;
+          font-weight: 600;
+        }
+      }
+
+      .tag-container {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 12px;
+
+        .tag {
+          padding: 4px 12px;
+          border-radius: 999px;
+          background: rgba(25, 118, 210, 0.15);
+          color: $secondary-color;
+          font-size: 12px;
+          letter-spacing: 0.4px;
+        }
+      }
+
+      .notes {
+        h3 {
+          margin: 0 0 8px;
+          font-size: 16px;
+          color: $secondary-color;
+        }
+
+        p {
+          margin: 0;
+          font-size: 14px;
+          color: $text-muted;
+          line-height: 1.6;
+          white-space: pre-line;
+        }
+      }
+    }
+
+    .feature-nav {
+      padding: 20px 0;
+      background: rgba(255, 255, 255, 0.95);
+      border-radius: 22px;
+      box-shadow: 0 12px 30px rgba(17, 71, 128, 0.12);
+      border: 1px solid rgba(25, 118, 210, 0.1);
+
+      h3 {
+        margin: 0 24px 12px;
+        font-size: 16px;
+        font-weight: 600;
+        color: $secondary-color;
+      }
+
+      .mat-mdc-nav-list .mat-mdc-list-item {
+        border-radius: 16px;
+        margin: 6px 12px;
+        padding: 12px;
+        transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+
+        .mat-mdc-list-item-meta {
+          margin: 0;
+        }
+
+        mat-icon[matListIcon] {
+          color: $primary-color;
+        }
+
+        .description {
+          font-size: 12px;
+          color: $text-muted;
+        }
+
+        .chevron {
+          margin-left: auto;
+          color: rgba(17, 71, 128, 0.3);
+        }
+
+        &.active,
+        &:hover,
+        &:focus {
+          background: rgba(25, 118, 210, 0.12);
+          box-shadow: inset 3px 0 0 $primary-color;
+          transform: translateX(2px);
+        }
+      }
+    }
+  }
+
+  .right-panel {
+    .tab-shell {
+      border-radius: 28px;
+      padding: 16px;
+      background: rgba(255, 255, 255, 0.98);
+      box-shadow: 0 24px 48px rgba(17, 71, 128, 0.18);
+      border: 1px solid rgba(25, 118, 210, 0.12);
+    }
+
+    ::ng-deep .mat-mdc-tab-group {
+      --mdc-tab-indicator-active-indicator-color: #1976d2;
+      --mat-tab-header-container-background-color: transparent;
+
+      .mdc-tab {
+        border-radius: 999px;
+        margin-right: 8px;
+        padding: 0 12px;
+        min-height: 44px;
+      }
+
+      .mdc-tab__text-label,
+      .mdc-tab__icon {
+        color: $secondary-color;
+      }
+
+      .mdc-tab-indicator__content--underline {
+        border-top-width: 0;
+      }
+
+      .mdc-tab--active .mdc-tab__text-label,
+      .mdc-tab--active .mdc-tab__icon {
+        color: $primary-color;
+      }
+
+      .mat-mdc-tab-body-content {
+        padding: 24px 12px 12px;
+      }
+    }
+
+    .tab-content {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+
+      h3 {
+        margin: 0;
+        font-size: 20px;
+        color: $secondary-color;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 16px;
+
+        .field {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+
+          label {
+            font-size: 13px;
+            color: $text-muted;
+            letter-spacing: 0.4px;
+          }
+
+          textarea {
+            resize: vertical;
+            padding: 12px;
+            border-radius: 14px;
+            border: 1px solid rgba(18, 66, 111, 0.2);
+            background: $surface-color;
+            font-family: inherit;
+            font-size: 14px;
+            color: #1c2b3a;
+            transition: border 0.2s ease, box-shadow 0.2s ease;
+
+            &:focus {
+              outline: none;
+              border-color: rgba(25, 118, 210, 0.7);
+              box-shadow: 0 0 0 3px rgba(25, 118, 210, 0.16);
+            }
+          }
+
+          &.full {
+            grid-column: span 2;
+          }
+        }
+      }
+
+      .action-bar {
+        display: flex;
+        justify-content: flex-end;
+        gap: 12px;
+      }
+
+      .placeholder {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        text-align: center;
+        padding: 48px 24px;
+        background: rgba(25, 118, 210, 0.06);
+        border-radius: 24px;
+        border: 1px dashed rgba(25, 118, 210, 0.2);
+        color: $text-muted;
+
+        mat-icon {
+          font-size: 42px;
+          width: 42px;
+          height: 42px;
+          color: $primary-color;
+        }
+      }
+
+      .records ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+
+        li {
+          padding: 16px;
+          border-radius: 18px;
+          background: rgba(25, 118, 210, 0.08);
+          color: #1c2b3a;
+
+          .label {
+            font-weight: 600;
+            color: $secondary-color;
+            margin-bottom: 6px;
+            display: inline-block;
+          }
+
+          p {
+            margin: 0;
+            color: $text-muted;
+          }
+        }
+      }
+
+      .empty {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        padding: 48px 24px;
+        color: $text-muted;
+
+        mat-icon {
+          font-size: 40px;
+          width: 40px;
+          height: 40px;
+          color: $primary-color;
+        }
+      }
+    }
+
+    .close[disabled] mat-icon {
+      opacity: 0.3;
+    }
+  }
+}
+
+@media (max-width: 1200px) {
+  .consultation-page {
+    padding: 24px;
+
+    .workspace {
+      grid-template-columns: 1fr;
+    }
+
+    .left-panel {
+      flex-direction: row;
+      align-items: stretch;
+      gap: 16px;
+      overflow-x: auto;
+
+      .patient-card,
+      .feature-nav {
+        min-width: 320px;
+      }
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .consultation-page {
+    padding: 16px;
+
+    .page-header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .left-panel {
+      flex-direction: column;
+    }
+
+    .right-panel .tab-content .grid {
+      grid-template-columns: 1fr;
+
+      .field.full {
+        grid-column: auto;
+      }
+    }
+  }
+}

--- a/src/app/pages/consultation/consultation.ts
+++ b/src/app/pages/consultation/consultation.ts
@@ -1,0 +1,188 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatListModule } from '@angular/material/list';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+interface PatientDetail {
+  id: string;
+  name: string;
+  gender: '男' | '女';
+  age: number;
+  dept: string;
+  doctor: string;
+  visitTime: string;
+  status: string;
+  allergies: string;
+  notes: string;
+  tags: string[];
+}
+
+interface ConsultationFeature {
+  id: FeatureKey;
+  title: string;
+  icon: string;
+  description: string;
+}
+
+type FeatureKey = 'diagnosis' | 'orders' | 'records' | 'certificate' | 'consent';
+
+@Component({
+  selector: 'app-consultation',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatCardModule,
+    MatIconModule,
+    MatButtonModule,
+    MatListModule,
+    MatTabsModule,
+    MatDividerModule,
+    MatTooltipModule
+  ],
+  templateUrl: './consultation.html',
+  styleUrls: ['./consultation.scss']
+})
+export class ConsultationComponent {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+
+  private readonly featureList: ConsultationFeature[] = [
+    {
+      id: 'diagnosis',
+      title: '诊断',
+      icon: 'medical_information',
+      description: '记录主诉与诊断结论'
+    },
+    {
+      id: 'orders',
+      title: '医嘱',
+      icon: 'medication',
+      description: '开立处方与医技检查'
+    },
+    {
+      id: 'records',
+      title: '病历',
+      icon: 'description',
+      description: '查看及补充病历信息'
+    },
+    {
+      id: 'certificate',
+      title: '疾病证明',
+      icon: 'verified',
+      description: '开具诊断证明或休假单'
+    },
+    {
+      id: 'consent',
+      title: '知情同意书',
+      icon: 'assignment_turned_in',
+      description: '签署及打印知情告知书'
+    }
+  ];
+
+  patient: PatientDetail | null = null;
+  openTabs: ConsultationFeature[] = [];
+  activeTabIndex = 0;
+
+  constructor() {
+    const patientId = this.route.snapshot.paramMap.get('id') ?? '';
+    this.patient = this.loadPatient(patientId);
+    const defaultFeature = this.featureList[0];
+    this.openTabs = [defaultFeature];
+    this.activeTabIndex = 0;
+  }
+
+  get features(): ConsultationFeature[] {
+    return this.featureList;
+  }
+
+  goBack(): void {
+    this.router.navigate(['/patients']);
+  }
+
+  openFeature(feature: ConsultationFeature): void {
+    const existingIndex = this.openTabs.findIndex((tab) => tab.id === feature.id);
+    if (existingIndex === -1) {
+      this.openTabs = [...this.openTabs, feature];
+      this.activeTabIndex = this.openTabs.length - 1;
+    } else {
+      this.activeTabIndex = existingIndex;
+    }
+  }
+
+  isFeatureActive(feature: ConsultationFeature): boolean {
+    return this.openTabs[this.activeTabIndex]?.id === feature.id;
+  }
+
+  closeTab(index: number, event: MouseEvent): void {
+    event.stopPropagation();
+    if (this.openTabs.length === 1) {
+      return;
+    }
+    const wasActive = index === this.activeTabIndex;
+    const newTabs = this.openTabs.filter((_, i) => i !== index);
+    this.openTabs = newTabs;
+    if (wasActive) {
+      this.activeTabIndex = Math.min(index, newTabs.length - 1);
+    } else if (index < this.activeTabIndex) {
+      this.activeTabIndex -= 1;
+    }
+  }
+
+  getTabDescription(id: FeatureKey): string {
+    return this.featureList.find((feature) => feature.id === id)?.description ?? '';
+  }
+
+  private loadPatient(id: string): PatientDetail {
+    const mockPatients: Record<string, PatientDetail> = {
+      P20241001: {
+        id: 'P20241001',
+        name: '张伟',
+        gender: '男',
+        age: 42,
+        dept: '心内科',
+        doctor: '李主任',
+        visitTime: '2024-10-10 09:20',
+        status: '候诊',
+        allergies: '青霉素',
+        notes: '血压波动较大，请重点关注。\n既往史：高血压10年，糖尿病3年。',
+        tags: ['高血压', '糖尿病', '随访']
+      },
+      P20241002: {
+        id: 'P20241002',
+        name: '王芳',
+        gender: '女',
+        age: 35,
+        dept: '呼吸内科',
+        doctor: '周医生',
+        visitTime: '2024-10-10 10:05',
+        status: '就诊中',
+        allergies: '无',
+        notes: '近期夜间咳嗽明显，需评估是否哮喘急性发作。',
+        tags: ['哮喘']
+      }
+    };
+
+    return (
+      mockPatients[id] ?? {
+        id,
+        name: '临时患者',
+        gender: '男',
+        age: 30,
+        dept: '全科门诊',
+        doctor: '值班医生',
+        visitTime: new Date().toISOString().slice(0, 16).replace('T', ' '),
+        status: '候诊',
+        allergies: '未记录',
+        notes: '暂无详细病史，请补充。',
+        tags: ['新建档案']
+      }
+    );
+  }
+}

--- a/src/app/pages/patient-list/patient-list.html
+++ b/src/app/pages/patient-list/patient-list.html
@@ -1,0 +1,76 @@
+<section class="patient-page">
+  <header class="page-header">
+    <div class="title-block">
+      <h1>患者信息</h1>
+      <p class="subtitle">查看当前候诊患者并快速进入看诊流程</p>
+    </div>
+    <button mat-raised-button color="primary" class="quick-register" (click)="navigateToRegistration()">
+      <mat-icon>playlist_add</mat-icon>
+      快速挂号
+    </button>
+  </header>
+
+  <mat-card class="patient-card">
+    <div class="card-toolbar">
+      <mat-form-field appearance="outline" class="search-field">
+        <mat-label>搜索患者姓名 / 卡号 / 科室 / 医生</mat-label>
+        <mat-icon matPrefix>search</mat-icon>
+        <input matInput type="search" placeholder="请输入关键字" [(ngModel)]="searchTerm" />
+        <button *ngIf="searchTerm" mat-icon-button matSuffix aria-label="清除" (click)="searchTerm = ''">
+          <mat-icon>close</mat-icon>
+        </button>
+      </mat-form-field>
+    </div>
+
+    <div class="table-wrapper">
+      <table class="patient-table">
+        <thead>
+          <tr>
+            <th>姓名</th>
+            <th>性别</th>
+            <th>年龄</th>
+            <th>就诊科室</th>
+            <th>主诊医生</th>
+            <th>状态</th>
+            <th>标签</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            *ngFor="let patient of filteredPatients"
+            (dblclick)="openConsultation(patient)"
+            class="patient-row"
+            tabindex="0"
+          >
+            <td>
+              <div class="name-cell">
+                <span class="name">{{ patient.name }}</span>
+                <span class="id">{{ patient.id }}</span>
+              </div>
+            </td>
+            <td>{{ patient.gender }}</td>
+            <td>{{ patient.age }}</td>
+            <td>{{ patient.dept }}</td>
+            <td>{{ patient.doctor }}</td>
+            <td>
+              <span class="status" [ngClass]="patient.status">{{ patient.status }}</span>
+            </td>
+            <td>
+              <div class="tag-list">
+                <span *ngFor="let tag of patient.tags" class="tag">{{ tag }}</span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="empty" *ngIf="filteredPatients.length === 0">
+        <mat-icon>sentiment_dissatisfied</mat-icon>
+        <p>未找到符合条件的患者</p>
+      </div>
+    </div>
+
+    <footer class="card-footer">
+      <p>双击患者行可快速进入看诊页面。</p>
+    </footer>
+  </mat-card>
+</section>

--- a/src/app/pages/patient-list/patient-list.scss
+++ b/src/app/pages/patient-list/patient-list.scss
@@ -1,0 +1,228 @@
+.patient-page {
+  min-height: 100vh;
+  padding: 32px 48px 48px;
+  background: linear-gradient(180deg, #f1f5ff 0%, #ffffff 65%);
+  box-sizing: border-box;
+  color: #1f2933;
+
+  .page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 24px;
+
+    .title-block {
+      h1 {
+        margin: 0;
+        font-size: 30px;
+        font-weight: 600;
+        color: #12426f;
+      }
+
+      .subtitle {
+        margin: 8px 0 0;
+        color: #5c6b7c;
+        font-size: 15px;
+      }
+    }
+
+    .quick-register {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 20px;
+      border-radius: 999px;
+      box-shadow: 0 10px 24px rgba(25, 118, 210, 0.2);
+    }
+  }
+
+  .patient-card {
+    padding: 24px 28px 16px;
+    border-radius: 20px;
+    box-shadow: 0 18px 45px rgba(15, 39, 73, 0.12);
+    border: 1px solid rgba(17, 86, 140, 0.12);
+    background: rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(6px);
+
+    .card-toolbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 16px;
+
+      .search-field {
+        flex: 1;
+
+        ::ng-deep .mdc-text-field--outlined {
+          border-radius: 16px;
+        }
+
+        input {
+          font-size: 15px;
+        }
+      }
+    }
+
+    .table-wrapper {
+      position: relative;
+      border-radius: 16px;
+      border: 1px solid rgba(18, 66, 111, 0.08);
+      overflow: hidden;
+      background: #ffffff;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+
+      .patient-table {
+        width: 100%;
+        border-collapse: collapse;
+
+        th {
+          background: #f3f7ff;
+          color: #3b5678;
+          font-weight: 600;
+          text-align: left;
+          padding: 16px 18px;
+          font-size: 14px;
+          border-bottom: 1px solid rgba(18, 66, 111, 0.12);
+        }
+
+        td {
+          padding: 14px 18px;
+          border-bottom: 1px solid rgba(18, 66, 111, 0.08);
+          font-size: 14px;
+          color: #1f2933;
+          vertical-align: middle;
+        }
+
+        .patient-row {
+          transition: background 0.2s ease, box-shadow 0.2s ease;
+          cursor: pointer;
+
+          &:hover,
+          &:focus {
+            background: rgba(25, 118, 210, 0.08);
+            box-shadow: inset 4px 0 0 #1976d2;
+          }
+
+          &:last-child td {
+            border-bottom: none;
+          }
+        }
+
+        .name-cell {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+
+          .name {
+            font-weight: 600;
+            font-size: 15px;
+          }
+
+          .id {
+            font-size: 12px;
+            color: #6c7a89;
+            letter-spacing: 0.5px;
+          }
+        }
+
+        .status {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          padding: 4px 12px;
+          border-radius: 999px;
+          font-size: 12px;
+          font-weight: 600;
+          letter-spacing: 0.5px;
+
+          &.候诊 {
+            background: rgba(25, 118, 210, 0.12);
+            color: #125ea2;
+          }
+
+          &.就诊中 {
+            background: rgba(0, 200, 83, 0.16);
+            color: #0f7a3c;
+          }
+
+          &.已就诊 {
+            background: rgba(158, 158, 158, 0.16);
+            color: #5a5a5a;
+          }
+        }
+
+        .tag-list {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+
+          .tag {
+            padding: 2px 10px;
+            border-radius: 12px;
+            font-size: 12px;
+            background: rgba(17, 86, 140, 0.1);
+            color: #12426f;
+          }
+        }
+      }
+
+      .empty {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 48px 24px;
+        gap: 12px;
+        color: #60748a;
+
+        mat-icon {
+          font-size: 48px;
+          width: 48px;
+          height: 48px;
+        }
+      }
+    }
+
+    .card-footer {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: 12px;
+      color: #60748a;
+      font-size: 13px;
+    }
+  }
+}
+
+@media (max-width: 960px) {
+  .patient-page {
+    padding: 24px;
+
+    .page-header {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 12px;
+
+      .quick-register {
+        width: 100%;
+        justify-content: center;
+      }
+    }
+
+    .patient-card {
+      padding: 20px;
+
+      .card-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+
+        .search-field {
+          width: 100%;
+        }
+      }
+
+      .table-wrapper {
+        overflow-x: auto;
+      }
+    }
+  }
+}

--- a/src/app/pages/patient-list/patient-list.ts
+++ b/src/app/pages/patient-list/patient-list.ts
@@ -1,0 +1,108 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router, RouterModule } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+
+interface PatientSummary {
+  id: string;
+  name: string;
+  gender: '男' | '女';
+  age: number;
+  dept: string;
+  doctor: string;
+  status: '候诊' | '就诊中' | '已就诊';
+  tags: string[];
+}
+
+@Component({
+  selector: 'app-patient-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    FormsModule,
+    MatButtonModule,
+    MatIconModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule
+  ],
+  templateUrl: './patient-list.html',
+  styleUrls: ['./patient-list.scss']
+})
+export class PatientListComponent {
+  private router = inject(Router);
+
+  searchTerm = '';
+
+  readonly patients: PatientSummary[] = [
+    {
+      id: 'P20241001',
+      name: '张伟',
+      gender: '男',
+      age: 42,
+      dept: '心内科',
+      doctor: '李主任',
+      status: '候诊',
+      tags: ['高血压', '二级随访']
+    },
+    {
+      id: 'P20241002',
+      name: '王芳',
+      gender: '女',
+      age: 35,
+      dept: '呼吸内科',
+      doctor: '周医生',
+      status: '就诊中',
+      tags: ['哮喘']
+    },
+    {
+      id: 'P20241003',
+      name: '刘强',
+      gender: '男',
+      age: 58,
+      dept: '内分泌科',
+      doctor: '陈医生',
+      status: '候诊',
+      tags: ['糖尿病', '定期复查']
+    },
+    {
+      id: 'P20241004',
+      name: '赵敏',
+      gender: '女',
+      age: 27,
+      dept: '妇产科',
+      doctor: '王主任',
+      status: '已就诊',
+      tags: ['产检']
+    }
+  ];
+
+  get filteredPatients(): PatientSummary[] {
+    if (!this.searchTerm.trim()) {
+      return this.patients;
+    }
+    const keyword = this.searchTerm.trim().toLowerCase();
+    return this.patients.filter((patient) => {
+      return (
+        patient.name.toLowerCase().includes(keyword) ||
+        patient.id.toLowerCase().includes(keyword) ||
+        patient.dept.toLowerCase().includes(keyword) ||
+        patient.doctor.toLowerCase().includes(keyword)
+      );
+    });
+  }
+
+  navigateToRegistration(): void {
+    this.router.navigate(['/registration']);
+  }
+
+  openConsultation(patient: PatientSummary): void {
+    this.router.navigate(['/consultation', patient.id]);
+  }
+}


### PR DESCRIPTION
## Summary
- add a styled patient list landing page with quick registration navigation and double-click entry to consultation
- build a consultation workspace with patient card, feature navigation, and dynamic tabbed content for diagnosis, orders, records, certificates, and consent
- update application routing so the patient list is the home view with routes to registration and consultation screens

## Testing
- npx ng test --watch=false --browsers=ChromeHeadless *(fails: No binary for ChromeHeadless browser on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_68d500973db4833188b6905f882ba63a