### PR TITLE
Adjust feature navigation icon alignment

### DIFF
--- a/src/app/pages/consultation/consultation.html
+++ b/src/app/pages/consultation/consultation.html
@@ -70,7 +70,9 @@
             (click)="openFeature(feature)"
             [class.active]="isFeatureActive(feature)"
           >
-            <mat-icon matListIcon>{{ feature.icon }}</mat-icon>
+            <span matListItemIcon class="icon-wrap">
+              <mat-icon>{{ feature.icon }}</mat-icon>
+            </span>
             <div class="text-group">
               <div matLine class="title">{{ feature.title }}</div>
               <p matLine class="description">{{ feature.description }}</p>

--- a/src/app/pages/consultation/consultation.scss
+++ b/src/app/pages/consultation/consultation.scss
@@ -254,17 +254,21 @@ $text-muted: #5c6b7c;
           margin: 0;
         }
 
-        mat-icon[matListIcon] {
-          color: $primary-color;
-          background: rgba(25, 118, 210, 0.08);
-          border-radius: 14px;
-          min-width: 44px;
-          min-height: 44px;
+        .icon-wrap {
           display: inline-flex;
           align-items: center;
           justify-content: center;
-          font-size: 22px;
+          width: 46px;
+          height: 46px;
+          border-radius: 16px;
+          background: rgba(25, 118, 210, 0.08);
+          color: $primary-color;
+          flex-shrink: 0;
           transition: background 0.2s ease, color 0.2s ease, box-shadow 0.25s ease;
+
+          mat-icon {
+            font-size: 22px;
+          }
         }
 
         .description {
@@ -294,6 +298,12 @@ $text-muted: #5c6b7c;
 
           .description {
             color: color.adjust($text-muted, $lightness: -8%);
+          }
+
+          .icon-wrap {
+            background: rgba(25, 118, 210, 0.16);
+            color: $secondary-color;
+            box-shadow: 0 6px 14px rgba(25, 118, 210, 0.18);
           }
 
           .chevron {


### PR DESCRIPTION
## Summary
- wrap the feature navigation icons in a dedicated container so they consistently render to the left of the text
- refresh the consultation page styles to center and highlight the icon container while keeping hover and active feedback aligned with the design system

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d51cfabe648331b7955cb8e63e510c