### PR TITLE
Adjust consultation navigation styling

### DIFF
--- a/src/app/pages/consultation/consultation.html
+++ b/src/app/pages/consultation/consultation.html
@@ -75,7 +75,6 @@
             </span>
             <div class="text-group">
               <div matLine class="title">{{ feature.title }}</div>
-              <p matLine class="description">{{ feature.description }}</p>
             </div>
             <mat-icon class="chevron">chevron_right</mat-icon>
           </a>

--- a/src/app/pages/consultation/consultation.scss
+++ b/src/app/pages/consultation/consultation.scss
@@ -197,7 +197,7 @@ $text-muted: #5c6b7c;
         border-radius: 18px;
         margin: 6px 0;
         padding: 14px 16px;
-        min-height: 72px;
+        min-height: 64px;
         border: 1px solid rgba(18, 66, 111, 0.08);
         transition:
           background 0.25s ease,
@@ -229,19 +229,20 @@ $text-muted: #5c6b7c;
 
         .text-group {
           display: flex;
-          flex-direction: column;
-          gap: 4px;
-          align-items: flex-start;
+          align-items: center;
           flex: 1 1 auto;
+          min-width: 0;
         }
 
         div[matLine].title {
           font-weight: 600;
           font-size: 15px;
           letter-spacing: 0.3px;
-          line-height: 1.4;
+          line-height: 1.5;
           color: #1b3144;
           transition: color 0.2s ease;
+          word-break: break-word;
+          white-space: normal;
         }
 
         .mat-mdc-list-item-meta,
@@ -271,14 +272,6 @@ $text-muted: #5c6b7c;
           }
         }
 
-        .description {
-          margin: 0;
-          font-size: 13px;
-          line-height: 1.6;
-          color: $text-muted;
-          letter-spacing: 0.2px;
-        }
-
         .chevron {
           margin-left: auto;
           color: rgba(17, 71, 128, 0.28);
@@ -293,16 +286,12 @@ $text-muted: #5c6b7c;
           transform: translateX(4px);
 
           div[matLine].title {
-            color: $secondary-color;
-          }
-
-          .description {
-            color: color.adjust($text-muted, $lightness: -8%);
+            color: $primary-color;
           }
 
           .icon-wrap {
             background: rgba(25, 118, 210, 0.16);
-            color: $secondary-color;
+            color: $primary-color;
             box-shadow: 0 6px 14px rgba(25, 118, 210, 0.18);
           }
 


### PR DESCRIPTION
## Summary
- remove the secondary description line from the consultation feature navigation items
- align active navigation icon and title colors with the primary tab accent to keep the UI consistent
- update navigation item layout to prevent text overflow while keeping the design compact

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d51fa62c408331a539706148ad5c2d