### PR TITLE
feat: add medical card number input to registration form

### DIFF
--- a/src/app/pages/form-demo/form-demo.html
+++ b/src/app/pages/form-demo/form-demo.html
@@ -38,6 +38,24 @@
     <mat-hint align="end">示例：13800001234</mat-hint>
     <mat-error *ngIf="submitted && form.controls.phone.invalid">手机号格式不正确</mat-error>
   </mat-form-field>
+
+  <!-- 文本输入：就诊卡号 -->
+  <mat-form-field appearance="outline">
+    <mat-label>就诊卡号</mat-label>
+    <input
+      matInput
+      placeholder="请输入 8-12 位数字就诊卡号"
+      formControlName="medicalCardNo"
+      maxlength="12"
+    >
+    <mat-hint align="end">例如：20240001</mat-hint>
+    <mat-error *ngIf="submitted && form.controls.medicalCardNo.errors?.['required']">
+      就诊卡号为必填项
+    </mat-error>
+    <mat-error *ngIf="submitted && form.controls.medicalCardNo.errors?.['pattern']">
+      请输入 8-12 位数字的就诊卡号
+    </mat-error>
+  </mat-form-field>
   <app-nationality-selector
     formControlName="nationality"
     [required]="true"

--- a/src/app/pages/form-demo/form-demo.ts
+++ b/src/app/pages/form-demo/form-demo.ts
@@ -48,17 +48,31 @@ export class FormDemoComponent {
   private fb = inject(FormBuilder);
 
   form = this.fb.group({
+    // 姓名：必填且至少输入两个字符，便于建立基础档案信息
     name: ['', [Validators.required, Validators.minLength(2)]],
+    // 性别：默认选中“男”，确保性别信息完整
     gender: ['male', Validators.required],
+    // 国籍：默认中国，提供必填校验
     nationality: ['CHN', Validators.required],
+    // 地区：借助 RegionSelectorComponent 选择省市区
     region: this.fb.control<RegionValue | null>(null),
+    // 民族：默认汉族编码“01”
     ethnic: ['01', Validators.required],
+    // 就诊科室：必选，便于后续分诊
     dept: ['', Validators.required],
+    // 出生日期：必填，配合日期控件选择
     birthday: [null, Validators.required],
+    // 手机号：可选，使用正则校验中国大陆 11 位手机号
     phone: ['', [Validators.pattern(/^1[3-9]\d{9}$/)]],
+    // 就诊卡号：必填，限制为 8-12 位数字，保障院内唯一性
+    medicalCardNo: ['', [Validators.required, Validators.pattern(/^\d{8,12}$/)]],
+    // 隐私协议同意：必须选中
     agree: [false, Validators.requiredTrue],
+    // 消息通知开关：默认启用
     enableNotify: [true],
+    // 疼痛等级：默认 3 级
     painLevel: [3],
+    // 标签：可输入关键字辅助标记
     tags: ['']
   });
 


### PR DESCRIPTION
## Summary
- add a required medical card number field to the quick registration form with validation and helper text
- document the updated form configuration with detailed Chinese comments for enterprise maintainability

## Testing
- npm test -- --watch=false *(fails: Chrome browser binary is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c7aa8bac833180f4368c6951e434