### PR TITLE
feat: split doctor login into credential and context steps

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,11 +3,13 @@ import { FormDemoComponent } from './pages/form-demo/form-demo';
 import { PatientListComponent } from './pages/patient-list/patient-list';
 import { ConsultationComponent } from './pages/consultation/consultation';
 import { DoctorLoginComponent } from './pages/doctor-login/doctor-login';
+import { DoctorLoginContextComponent } from './pages/doctor-login-context/context-select';
 import { QuickLoginComponent } from './pages/quick-login/quick-login';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'doctor-login', pathMatch: 'full' },
   { path: 'doctor-login', component: DoctorLoginComponent },
+  { path: 'doctor-login/context', component: DoctorLoginContextComponent },
   { path: 'quick-login', component: QuickLoginComponent },
   { path: 'patients', component: PatientListComponent },
   { path: 'registration', component: FormDemoComponent },

--- a/src/app/pages/doctor-login-context/context-select.html
+++ b/src/app/pages/doctor-login-context/context-select.html
@@ -1,0 +1,58 @@
+<div class="context-layout">
+  <mat-card class="context-card">
+    <mat-card-header>
+      <div mat-card-avatar class="brand-avatar">H</div>
+      <mat-card-title>{{ doctorName }}医生，选择工作场景</mat-card-title>
+      <mat-card-subtitle>系统将根据权限提供匹配入口</mat-card-subtitle>
+    </mat-card-header>
+
+    <mat-card-content>
+      <form [formGroup]="contextForm" (ngSubmit)="submit()">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>选择系统</mat-label>
+          <mat-select formControlName="system" (selectionChange)="onSystemChanged($event.value)">
+            <mat-option *ngFor="let system of systemOptions" [value]="system.value">
+              <div class="option-title">{{ system.label }}</div>
+              <div class="option-desc">{{ system.description }}</div>
+            </mat-option>
+          </mat-select>
+          <mat-error *ngIf="contextForm.controls.system.invalid">请选择系统</mat-error>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>选择院区</mat-label>
+          <mat-select formControlName="campus" (selectionChange)="onCampusChanged($event.value)">
+            <mat-option *ngFor="let campus of campusOptions" [value]="campus.value">{{ campus.label }}</mat-option>
+          </mat-select>
+          <mat-error *ngIf="contextForm.controls.campus.invalid">请选择院区</mat-error>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>选择科室</mat-label>
+          <mat-select formControlName="department">
+            <mat-option *ngFor="let dept of departmentOptions" [value]="dept.value">{{ dept.label }}</mat-option>
+          </mat-select>
+          <mat-error *ngIf="contextForm.controls.department.invalid">请选择科室</mat-error>
+        </mat-form-field>
+
+        <div class="remember-tip" *ngIf="rememberMe">已为您保留账号信息，无需重复输入。</div>
+
+        <button mat-flat-button color="primary" class="submit-btn" [disabled]="isSubmitting" type="submit">
+          {{ isSubmitting ? '加载中…' : '进入系统' }}
+        </button>
+      </form>
+    </mat-card-content>
+
+    <mat-divider></mat-divider>
+
+    <mat-card-footer>
+      <div class="hint-title">温馨提示</div>
+      <ul>
+        <li *ngFor="let hint of hints">{{ hint }}</li>
+      </ul>
+      <div class="back-action">
+        <button mat-stroked-button color="accent" (click)="backToLogin()">返回重新登录</button>
+      </div>
+    </mat-card-footer>
+  </mat-card>
+</div>

--- a/src/app/pages/doctor-login-context/context-select.scss
+++ b/src/app/pages/doctor-login-context/context-select.scss
@@ -1,4 +1,4 @@
-/* 页面背景采用柔和渐变，保证医疗系统的宁静氛围。 */
+/* 第二步登录页面延续主登录配色，保证整体视觉统一。 */
 :host {
   display: flex;
   min-height: 100vh;
@@ -8,20 +8,19 @@
   font-family: 'Microsoft YaHei', 'PingFang SC', 'Hiragino Sans GB', sans-serif;
 }
 
-.login-layout {
-  width: min(420px, 92vw);
+.context-layout {
+  width: min(520px, 94vw);
   padding: 32px 0;
 }
 
-.login-card {
-  box-shadow: 0 18px 40px rgba(51, 99, 255, 0.15);
+.context-card {
+  box-shadow: 0 18px 40px rgba(63, 81, 181, 0.18);
   border-radius: 20px;
   overflow: hidden;
-  backdrop-filter: blur(2px);
 }
 
 .brand-avatar {
-  background: linear-gradient(135deg, #3f51b5, #5c6bc0);
+  background: linear-gradient(135deg, #3949ab, #5c6bc0);
   color: #fff;
   font-weight: 600;
 }
@@ -45,16 +44,25 @@ mat-card-content {
   margin-bottom: 16px;
 }
 
-.form-actions {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-  margin-top: 8px;
+.option-title {
+  font-weight: 600;
+  color: #303f9f;
+}
+
+.option-desc {
+  font-size: 12px;
+  color: #5c6bc0;
+}
+
+.remember-tip {
+  margin-bottom: 12px;
+  color: #5c6bc0;
+  font-size: 13px;
 }
 
 .submit-btn {
-  min-width: 120px;
+  width: 100%;
+  margin-top: 8px;
   background: linear-gradient(135deg, #3f51b5, #536dfe);
   color: #fff;
   box-shadow: 0 10px 22px rgba(83, 109, 254, 0.25);
@@ -82,15 +90,13 @@ ul {
   line-height: 1.6;
 }
 
-.quick-links {
+.back-action {
   display: flex;
-  align-items: center;
-  gap: 12px;
-  color: #5c6bc0;
+  justify-content: flex-end;
 }
 
-@media (max-width: 480px) {
-  .login-card {
+@media (max-width: 520px) {
+  .context-card {
     border-radius: 16px;
   }
 

--- a/src/app/pages/doctor-login-context/context-select.ts
+++ b/src/app/pages/doctor-login-context/context-select.ts
@@ -1,0 +1,205 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router, RouterModule } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatDividerModule } from '@angular/material/divider';
+import {
+  DoctorLoginFlowService,
+  DoctorCampusOption,
+  DoctorDepartmentOption,
+  DoctorSystemOption
+} from '../../services/doctor-login-flow.service';
+
+@Component({
+  selector: 'app-doctor-login-context',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatSnackBarModule,
+    MatDividerModule
+  ],
+  templateUrl: './context-select.html',
+  styleUrls: ['./context-select.scss']
+})
+export class DoctorLoginContextComponent implements OnInit {
+  private readonly fb = inject(FormBuilder);
+  private readonly router = inject(Router);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly loginFlow = inject(DoctorLoginFlowService);
+
+  /** 是否处于提交阶段，用于交互反馈。 */
+  isSubmitting = false;
+
+  /** 当前登录医生姓名，便于标题问候。 */
+  doctorName = '';
+
+  /** 登录第一步的记住账号配置，作为提示展示。 */
+  rememberMe = false;
+
+  /** 系统权限选项，依据账号校验结果动态生成。 */
+  systemOptions: DoctorSystemOption[] = [];
+
+  /** 当前系统下可选的院区列表。 */
+  campusOptions: DoctorCampusOption[] = [];
+
+  /** 当前院区下可选的科室列表。 */
+  departmentOptions: DoctorDepartmentOption[] = [];
+
+  /** 页面引导文案，体现分步登录体验。 */
+  readonly hints: string[] = [
+    '仅展示您有权限访问的系统、院区及科室，避免误入其他业务线。',
+    '如需开通更多权限，请联系科室主任或信息科管理员。'
+  ];
+
+  /**
+   * 权限选择表单，仅包含系统、院区、科室三级字段。
+   */
+  readonly contextForm = this.fb.group({
+    system: ['', Validators.required],
+    campus: ['', Validators.required],
+    department: ['', Validators.required]
+  });
+
+  ngOnInit(): void {
+    const profile = this.loginFlow.getActiveProfile();
+    if (!profile) {
+      this.snackBar.open('登录信息已过期，请重新验证账号。', '重新登录', {
+        duration: 3000
+      });
+      this.router.navigate(['/doctor-login']);
+      return;
+    }
+
+    this.doctorName = profile.displayName;
+    this.systemOptions = profile.systems;
+    this.rememberMe = this.loginFlow.getRememberMe();
+    this.initializeDefaultSelections();
+  }
+
+  /**
+   * 初始化默认选择，确保表单拥有有效值。
+   */
+  private initializeDefaultSelections(): void {
+    const firstSystem = this.systemOptions[0];
+    if (!firstSystem) {
+      this.contextForm.reset();
+      return;
+    }
+
+    this.updateCampusOptions(firstSystem.value);
+    const firstCampus = this.campusOptions[0];
+    this.departmentOptions = firstCampus?.departments ?? [];
+    const firstDepartment = this.departmentOptions[0];
+
+    this.contextForm.patchValue({
+      system: firstSystem.value,
+      campus: firstCampus?.value ?? '',
+      department: firstDepartment?.value ?? ''
+    });
+  }
+
+  /**
+   * 系统切换时重建院区与科室选项，确保层级联动。
+   */
+  onSystemChanged(systemValue: string): void {
+    this.updateCampusOptions(systemValue);
+    const firstCampus = this.campusOptions[0];
+    this.departmentOptions = firstCampus?.departments ?? [];
+    const firstDepartment = this.departmentOptions[0];
+
+    this.contextForm.patchValue({
+      campus: firstCampus?.value ?? '',
+      department: firstDepartment?.value ?? ''
+    });
+  }
+
+  /**
+   * 院区切换时重置科室，避免跨院区误选。
+   */
+  onCampusChanged(campusValue: string): void {
+    const campus = this.campusOptions.find((item) => item.value === campusValue);
+    this.departmentOptions = campus?.departments ?? [];
+    const fallbackDepartment = this.departmentOptions[0]?.value ?? '';
+    this.contextForm.patchValue({ department: fallbackDepartment });
+  }
+
+  /**
+   * 提交最终登录信息，提示成功后跳转到患者列表。
+   */
+  submit(): void {
+    if (this.contextForm.invalid) {
+      this.contextForm.markAllAsTouched();
+      this.snackBar.open('请选择完整的系统、院区与科室信息。', '好的', {
+        duration: 2600
+      });
+      return;
+    }
+
+    this.isSubmitting = true;
+    const { system, campus, department } = this.contextForm.getRawValue();
+    const systemLabel = this.getSystemLabel(system ?? '');
+    const campusLabel = this.getCampusLabel(campus ?? '', system ?? '');
+    const departmentLabel = this.getDepartmentLabel(department ?? '', campus ?? '', system ?? '');
+
+    window.setTimeout(() => {
+      this.isSubmitting = false;
+      this.snackBar.open(
+        `${this.doctorName}医生，已为您开启 ${campusLabel}${departmentLabel}${systemLabel}。`,
+        undefined,
+        {
+          duration: 2800
+        }
+      );
+      this.loginFlow.clearSession();
+      this.router.navigate(['/patients']);
+    }, 500);
+  }
+
+  /**
+   * 根据系统值更新院区列表。
+   */
+  private updateCampusOptions(systemValue: string): void {
+    const system = this.systemOptions.find((item) => item.value === systemValue);
+    this.campusOptions = system?.campuses ?? [];
+    this.departmentOptions = this.campusOptions[0]?.departments ?? [];
+  }
+
+  private getSystemLabel(systemValue: string): string {
+    return this.systemOptions.find((item) => item.value === systemValue)?.label ?? '';
+  }
+
+  private getCampusLabel(campusValue: string, systemValue: string): string {
+    const system = this.systemOptions.find((item) => item.value === systemValue);
+    return system?.campuses.find((item) => item.value === campusValue)?.label ?? '';
+  }
+
+  private getDepartmentLabel(
+    departmentValue: string,
+    campusValue: string,
+    systemValue: string
+  ): string {
+    const system = this.systemOptions.find((item) => item.value === systemValue);
+    const campus = system?.campuses.find((item) => item.value === campusValue);
+    const department = campus?.departments.find((item) => item.value === departmentValue);
+    return department ? `${department.label}` : '';
+  }
+
+  /**
+   * 返回账号验证页，便于重新选择登录用户。
+   */
+  backToLogin(): void {
+    this.loginFlow.clearSession();
+    this.router.navigate(['/doctor-login']);
+  }
+}

--- a/src/app/pages/doctor-login/doctor-login.html
+++ b/src/app/pages/doctor-login/doctor-login.html
@@ -1,75 +1,60 @@
-<section class="doctor-login-page">
-  <div class="background-glow"></div>
+<div class="login-layout">
   <mat-card class="login-card">
-    <div class="card-hero">
-      <div class="logo-circle">
-        <mat-icon>local_hospital</mat-icon>
-      </div>
-      <div class="hero-text">
-        <h1>医生工作站登录</h1>
-        <p>连接智能诊疗平台，随时掌握候诊患者动态。</p>
-      </div>
-    </div>
+    <mat-card-header>
+      <div mat-card-avatar class="brand-avatar">H</div>
+      <mat-card-title>医生统一账号登录</mat-card-title>
+      <mat-card-subtitle>先验证身份，再进入科室场景</mat-card-subtitle>
+    </mat-card-header>
 
     <mat-card-content>
-      <form class="form" [formGroup]="loginForm" (ngSubmit)="submit()">
-        <mat-form-field appearance="outline">
-          <mat-label>工号 / 手机号</mat-label>
-          <mat-icon matPrefix>badge</mat-icon>
-          <input matInput formControlName="username" placeholder="请输入账号信息" />
-          <mat-error *ngIf="loginForm.controls.username.hasError('required')">
-            请输入登录账号
-          </mat-error>
-          <mat-error *ngIf="loginForm.controls.username.hasError('minlength')">
-            至少输入 3 个字符
-          </mat-error>
+      <form [formGroup]="loginForm" (ngSubmit)="submit()" autocomplete="off">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>账号</mat-label>
+          <mat-icon matPrefix color="primary">badge</mat-icon>
+          <input matInput formControlName="username" maxlength="32" placeholder="请输入工号/手机号" />
+          <mat-hint align="end">至少 3 位字符</mat-hint>
+          <mat-error *ngIf="loginForm.controls.username.hasError('required')">账号不能为空</mat-error>
+          <mat-error *ngIf="loginForm.controls.username.hasError('minlength')">账号长度不足</mat-error>
         </mat-form-field>
 
-        <mat-form-field appearance="outline">
-          <mat-label>登录密码</mat-label>
-          <mat-icon matPrefix>lock</mat-icon>
-          <input matInput type="password" formControlName="password" placeholder="请输入密码" />
-          <mat-error *ngIf="loginForm.controls.password.hasError('required')">
-            密码不能为空
-          </mat-error>
-          <mat-error *ngIf="loginForm.controls.password.hasError('minlength')">
-            至少输入 6 位密码
-          </mat-error>
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>密码</mat-label>
+          <mat-icon matPrefix color="primary">lock</mat-icon>
+          <input
+            matInput
+            [type]="hidePassword ? 'password' : 'text'"
+            formControlName="password"
+            maxlength="32"
+            placeholder="请输入登录密码"
+          />
+          <button mat-icon-button matSuffix type="button" (click)="hidePassword = !hidePassword" [attr.aria-label]="hidePassword ? '显示密码' : '隐藏密码'">
+            <mat-icon>{{ hidePassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+          </button>
+          <mat-hint align="end">至少 6 位字符</mat-hint>
+          <mat-error *ngIf="loginForm.controls.password.hasError('required')">密码不能为空</mat-error>
+          <mat-error *ngIf="loginForm.controls.password.hasError('minlength')">密码长度不足</mat-error>
         </mat-form-field>
 
-        <div class="form-footer">
-          <mat-checkbox formControlName="remember">记住登录状态</mat-checkbox>
-          <button type="button" mat-button class="quick-link" (click)="navigateToQuickLogin()">
-            <mat-icon>bolt</mat-icon>
-            快速登录
+        <div class="form-actions">
+          <mat-checkbox formControlName="remember">记住账号</mat-checkbox>
+          <button mat-flat-button color="primary" class="submit-btn" [disabled]="isSubmitting" type="submit">
+            {{ isSubmitting ? '校验中…' : '下一步' }}
           </button>
         </div>
-
-        <button mat-flat-button color="primary" class="submit" type="submit" [disabled]="isSubmitting">
-          <mat-icon>login</mat-icon>
-          登录平台
-        </button>
-
-        <button
-          mat-stroked-button
-          color="primary"
-          type="button"
-          class="secondary"
-          (click)="navigateToQuickLogin()"
-        >
-          <mat-icon>travel_explore</mat-icon>
-          使用访客通道
-        </button>
       </form>
-
-      <mat-divider></mat-divider>
-
-      <ul class="tips">
-        <li *ngFor="let tip of hints">
-          <mat-icon>info</mat-icon>
-          <span>{{ tip }}</span>
-        </li>
-      </ul>
     </mat-card-content>
+
+    <mat-divider></mat-divider>
+
+    <mat-card-footer>
+      <div class="hint-title">使用建议</div>
+      <ul>
+        <li *ngFor="let hint of hints">{{ hint }}</li>
+      </ul>
+      <div class="quick-links">
+        <span>没有正式账号？</span>
+        <button mat-stroked-button color="accent" (click)="navigateToQuickLogin()">体验版快速登录</button>
+      </div>
+    </mat-card-footer>
   </mat-card>
-</section>
+</div>

--- a/src/app/pages/doctor-login/doctor-login.ts
+++ b/src/app/pages/doctor-login/doctor-login.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
@@ -8,8 +8,9 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatDividerModule } from '@angular/material/divider';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatDividerModule } from '@angular/material/divider';
+import { DoctorLoginFlowService } from '../../services/doctor-login-flow.service';
 
 @Component({
   selector: 'app-doctor-login',
@@ -24,52 +25,82 @@ import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
     MatInputModule,
     MatIconModule,
     MatCheckboxModule,
-    MatDividerModule,
-    MatSnackBarModule
+    MatSnackBarModule,
+    MatDividerModule
   ],
   templateUrl: './doctor-login.html',
   styleUrls: ['./doctor-login.scss']
 })
-export class DoctorLoginComponent {
+export class DoctorLoginComponent implements OnInit {
   private readonly fb = inject(FormBuilder);
   private readonly router = inject(Router);
   private readonly snackBar = inject(MatSnackBar);
+  private readonly loginFlow = inject(DoctorLoginFlowService);
 
+  /** 是否隐藏密码，保障账号安全。 */
+  hidePassword = true;
+  /** 登录提交中标志，用于控制按钮 loading 状态。 */
   isSubmitting = false;
 
+  /**
+   * 登录提示语，帮助医护人员快速了解产品能力。
+   */
+  readonly hints: string[] = [
+    '统一账号由信息中心维护，如忘记密码可通过自助终端找回。',
+    '首次登录建议开启「记住账号」以提升诊间效率。'
+  ];
+
+  /**
+   * 登录表单，仅承载账号密码与记住账号配置。
+   */
   readonly loginForm = this.fb.group({
     username: ['', [Validators.required, Validators.minLength(3)]],
     password: ['', [Validators.required, Validators.minLength(6)]],
     remember: [true]
   });
 
-  readonly hints: string[] = [
-    '推荐使用医院统一账号登录，系统自动同步排班。',
-    '首次登录后可在设置中绑定手机，提升安全性。'
-  ];
+  ngOnInit(): void {
+    // 每次进入账号验证页时都清理上一次的登录流程，避免残留权限数据。
+    this.loginFlow.clearSession();
+  }
 
+  /**
+   * 执行账号密码校验，通过后跳转至权限选择页面。
+   */
   submit(): void {
     if (this.loginForm.invalid) {
       this.loginForm.markAllAsTouched();
-      this.snackBar.open('请完整填写账号与密码后再登录。', '好的', {
+      this.snackBar.open('请先完整填写账号与密码。', '我知道了', {
         duration: 2800
       });
       return;
     }
 
     this.isSubmitting = true;
-
-    const { username } = this.loginForm.getRawValue();
+    const { username, password, remember } = this.loginForm.getRawValue();
 
     window.setTimeout(() => {
+      const profile = this.loginFlow.authenticate(username ?? '', password ?? '', !!remember);
       this.isSubmitting = false;
-      this.snackBar.open(`欢迎您，${username}，已为您打开候诊患者列表。`, undefined, {
+
+      if (!profile) {
+        this.snackBar.open('账号或密码有误，请重新输入。', '重试', {
+          duration: 3000
+        });
+        this.loginForm.controls.password.reset('');
+        return;
+      }
+
+      this.snackBar.open(`欢迎您，${profile.displayName}医生，请继续选择登录场景。`, undefined, {
         duration: 2600
       });
-      this.router.navigate(['/patients']);
-    }, 600);
+      this.router.navigate(['/doctor-login/context']);
+    }, 500);
   }
 
+  /**
+   * 提供快速通道给体验账号使用者，减少阻碍。
+   */
   navigateToQuickLogin(): void {
     this.router.navigate(['/quick-login']);
   }

--- a/src/app/services/doctor-login-flow.service.ts
+++ b/src/app/services/doctor-login-flow.service.ts
@@ -1,0 +1,164 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * 医生登录过程中涉及的科室基础类型定义，确保下游模块严格受控。
+ */
+export interface DoctorDepartmentOption {
+  /** 唯一值，通常对应 HIS 系统内的科室编码。 */
+  value: string;
+  /** 中文名称，直接呈现在界面上。 */
+  label: string;
+}
+
+/**
+ * 医生登录过程中涉及的院区选项，包含院区下属科室。
+ */
+export interface DoctorCampusOption {
+  value: string;
+  label: string;
+  departments: DoctorDepartmentOption[];
+}
+
+/**
+ * 医生系统选项，内含院区层级，便于一次性获取权限树。
+ */
+export interface DoctorSystemOption {
+  value: string;
+  label: string;
+  description: string;
+  campuses: DoctorCampusOption[];
+}
+
+/**
+ * 医生账号权限配置，模拟来自后端的鉴权结果。
+ */
+export interface DoctorPermissionProfile {
+  username: string;
+  /** 姓名用于问候语展示。 */
+  displayName: string;
+  /** 演示环境中的明文密码，真实环境需改为密文。 */
+  password: string;
+  systems: DoctorSystemOption[];
+}
+
+interface DoctorSessionState {
+  profile: DoctorPermissionProfile;
+  rememberMe: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class DoctorLoginFlowService {
+  /**
+   * 内部权限表，后续可替换为 API 调用或数据字典服务。
+   */
+  private readonly permissionProfiles: DoctorPermissionProfile[] = [
+    {
+      username: 'zhangsan',
+      displayName: '张三',
+      password: 'doctor123',
+      systems: [
+        {
+          value: 'outpatient',
+          label: '门诊医生站',
+          description: '覆盖门诊排班、叫号与病历录入能力。',
+          campuses: [
+            {
+              value: 'main',
+              label: '本部院区',
+              departments: [
+                { value: 'cardiology', label: '心内科' },
+                { value: 'respiratory', label: '呼吸与危重症医学科' },
+                { value: 'emergency', label: '急诊科' }
+              ]
+            },
+            {
+              value: 'east',
+              label: '东城院区',
+              departments: [
+                { value: 'surgery', label: '普外科' },
+                { value: 'orthopedics', label: '骨科' }
+              ]
+            }
+          ]
+        },
+        {
+          value: 'inpatient',
+          label: '住院医生站',
+          description: '聚焦住院病程管理与医嘱执行追踪。',
+          campuses: [
+            {
+              value: 'main',
+              label: '本部院区',
+              departments: [
+                { value: 'nephrology', label: '肾内科' },
+                { value: 'endocrinology', label: '内分泌科' }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      username: 'lisi',
+      displayName: '李四',
+      password: 'secure456',
+      systems: [
+        {
+          value: 'outpatient',
+          label: '门诊医生站',
+          description: '提供门诊业务相关功能入口。',
+          campuses: [
+            {
+              value: 'south',
+              label: '南湖院区',
+              departments: [
+                { value: 'pediatrics', label: '儿科' },
+                { value: 'obstetrics', label: '产科' }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ];
+
+  /** 当前登录流程状态，仅在两步登录过程中保留。 */
+  private activeSession: DoctorSessionState | null = null;
+
+  /**
+   * 校验账号密码是否匹配，匹配后缓存对应权限树。
+   */
+  authenticate(username: string, password: string, rememberMe: boolean): DoctorPermissionProfile | null {
+    const trimmedUsername = username.trim();
+    const profile = this.permissionProfiles.find(
+      (item) => item.username === trimmedUsername && item.password === password
+    );
+
+    if (!profile) {
+      this.activeSession = null;
+      return null;
+    }
+
+    this.activeSession = { profile, rememberMe };
+    return profile;
+  }
+
+  /** 获取当前登录流程中的权限信息，若为空则需重新登录。 */
+  getActiveProfile(): DoctorPermissionProfile | null {
+    return this.activeSession?.profile ?? null;
+  }
+
+  /**
+   * 记住密码开关状态，便于第二步根据用户偏好提供提示。
+   */
+  getRememberMe(): boolean {
+    return this.activeSession?.rememberMe ?? false;
+  }
+
+  /**
+   * 完成登录流程或异常时，需清理缓存状态以防权限泄露。
+   */
+  clearSession(): void {
+    this.activeSession = null;
+  }
+}


### PR DESCRIPTION
## Summary
- split the doctor login into credential verification and context selection pages with refreshed styling
- add a DoctorLoginFlowService to hold permission-based system, campus, and department options and filter them after authentication
- update routing and context UI messaging to guide clinicians through the new two-step experience

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d8ae2c3424833192ffbcb8b0d43ffe